### PR TITLE
Update aldc to use release branch instead of tagged releases

### DIFF
--- a/aldc
+++ b/aldc
@@ -1,14 +1,13 @@
 #! /bin/bash
 # aldc: Add LaTeX DevContainer
 
-RELEASE=0.4.1
 REPOSITORY_NAME='latex-environment'
 REPOSITORY_OWNER='smkwlab'
 REPOSITORY_URL="https://github.com/${REPOSITORY_OWNER}/${REPOSITORY_NAME}"
-RELEASE_BASE="${REPOSITORY_NAME}-${RELEASE}"
-ZIP_NAME="${RELEASE_BASE}.zip"
+BRANCH='release'
+ZIP_NAME="${REPOSITORY_NAME}-${BRANCH}.zip"
 
-TARGET=${REPOSITORY_URL}/archive/refs/tags/v${RELEASE}.zip
+TARGET=${REPOSITORY_URL}/archive/refs/heads/${BRANCH}.zip
 
 if [ -d .devcontainer ]; then
   echo "The LaTeX environment already exists."
@@ -28,7 +27,7 @@ echo download LaTeX environment
 curl -sLJO ${TARGET}
 unzip -q ${ZIP_NAME}
 rm ${ZIP_NAME}
-cd ${RELEASE_BASE}
+cd ${REPOSITORY_NAME}-${BRANCH}
 
 echo Integrate LaTeX environment
 backups=""


### PR DESCRIPTION
## Summary
Update aldc to consume from the latex-environment release branch instead of versioned tags.

## Changes
- Remove hardcoded RELEASE version variable
- Change download URL to use release branch ()
- Update directory extraction logic for branch-based archives

## Benefits
- **Automatic updates**: No manual version bumps needed
- **Clean environment**: Release branch excludes CI/CD workflows  
- **Simplified maintenance**: Eliminates version synchronization issues

## Testing
Tested with release branch containing latest latex-environment files without workflows.

## Breaking Change
This changes the update mechanism but maintains the same functionality for end users.