### PR TITLE
Add quiet mode support for aldc

### DIFF
--- a/aldc
+++ b/aldc
@@ -15,8 +15,8 @@ if [ "${ALDC_QUIET:-}" = "1" ]; then
     QUIET=true
 fi
 
-for arg in "$@"; do
-    case $arg in
+while [ $# -gt 0 ]; do
+    case $1 in
         --quiet|-q)
             QUIET=true
             shift
@@ -35,7 +35,9 @@ for arg in "$@"; do
             exit 0
             ;;
         *)
-            # Unknown option
+            echo "Unknown option: $1" >&2
+            echo "Use --help for usage information" >&2
+            exit 1
             ;;
     esac
 done

--- a/aldc
+++ b/aldc
@@ -9,8 +9,46 @@ ZIP_NAME="${REPOSITORY_NAME}-${BRANCH}.zip"
 
 TARGET=${REPOSITORY_URL}/archive/refs/heads/${BRANCH}.zip
 
+# Parse command line arguments for quiet mode
+QUIET=false
+if [ "${ALDC_QUIET:-}" = "1" ]; then
+    QUIET=true
+fi
+
+for arg in "$@"; do
+    case $arg in
+        --quiet|-q)
+            QUIET=true
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: aldc [--quiet|-q] [--help|-h]"
+            echo ""
+            echo "Add LaTeX DevContainer to the current directory."
+            echo ""
+            echo "Options:"
+            echo "  --quiet, -q     Suppress output messages"
+            echo "  --help, -h      Show this help message"
+            echo ""
+            echo "Environment Variables:"
+            echo "  ALDC_QUIET=1    Enable quiet mode"
+            exit 0
+            ;;
+        *)
+            # Unknown option
+            ;;
+    esac
+done
+
+# Logging function
+log() {
+    if [ "$QUIET" = "false" ]; then
+        echo "$1"
+    fi
+}
+
 if [ -d .devcontainer ]; then
-  echo "The LaTeX environment already exists."
+  log "The LaTeX environment already exists."
   exit
 fi
 
@@ -18,18 +56,21 @@ GIT_INIT=false
 if [ ! -d .git ]; then
   git init .
   git add .
-  git rm --cached aldc
+  # aldcファイルが存在する場合のみ除外
+  if git ls-files --cached | grep -q "^aldc$"; then
+    git rm --cached aldc
+  fi
   git commit -m "initial commit"
   GIT_INIT=true
 fi
 
-echo download LaTeX environment
+log "download LaTeX environment"
 curl -sLJO ${TARGET}
 unzip -q ${ZIP_NAME}
 rm ${ZIP_NAME}
 cd ${REPOSITORY_NAME}-${BRANCH}
 
-echo Integrate LaTeX environment
+log "Integrate LaTeX environment"
 backups=""
 for i in $(find . -type f); do
     if [ -e ../${i} ]; then
@@ -51,8 +92,8 @@ git add .
 git commit --quiet --porcelain -m "add LaTeX environment"
 # [ "${GIT_INIT}" != "true" ] && git push --quiet
 
-echo "The LaTeX environment integration is complete."
+log "The LaTeX environment integration is complete."
 
 if [ "${backups}" != "" ]; then
-    echo You may delete the following files: ${backups}
+    log "You may delete the following files: ${backups}"
 fi


### PR DESCRIPTION
## Summary
- Add --quiet/-q flag and ALDC_QUIET environment variable support
- Convert output messages to use log() function for conditional display  
- Fix git rm issue when aldc file doesn't exist in target directory
- Enable silent execution for integration in setup scripts

## Features
- **Command line flag**: `aldc --quiet` or `aldc -q`
- **Environment variable**: `ALDC_QUIET=1 aldc`
- **Help option**: `aldc --help` or `aldc -h`

## Benefits
- Cleaner output when integrated in setup scripts
- Better user experience for automated workflows
- Maintains full functionality with optional verbosity control

## Test plan
- [x] Test quiet mode with --quiet flag
- [x] Test quiet mode with ALDC_QUIET=1
- [x] Test normal mode still shows messages
- [x] Test help output
- [x] Test git operations in directories without aldc file