### PR TITLE
Fix git command output in quiet mode

### DIFF
--- a/aldc
+++ b/aldc
@@ -56,13 +56,23 @@ fi
 
 GIT_INIT=false
 if [ ! -d .git ]; then
-  git init .
-  git add .
-  # aldcファイルが存在する場合のみ除外
-  if git ls-files --cached | grep -q "^aldc$"; then
-    git rm --cached aldc
+  if [ "$QUIET" = "false" ]; then
+    git init .
+    git add .
+    # aldcファイルが存在する場合のみ除外
+    if git ls-files --cached | grep -q "^aldc$"; then
+      git rm --cached aldc
+    fi
+    git commit -m "initial commit"
+  else
+    git init . >/dev/null 2>&1
+    git add . >/dev/null 2>&1
+    # aldcファイルが存在する場合のみ除外
+    if git ls-files --cached | grep -q "^aldc$"; then
+      git rm --cached aldc >/dev/null 2>&1
+    fi
+    git commit -m "initial commit" >/dev/null 2>&1
   fi
-  git commit -m "initial commit"
   GIT_INIT=true
 fi
 
@@ -90,8 +100,13 @@ done
 cd ..
 rm -rf ${RELEASE_BASE}
 
-git add .
-git commit --quiet --porcelain -m "add LaTeX environment"
+if [ "$QUIET" = "false" ]; then
+    git add .
+    git commit --quiet --porcelain -m "add LaTeX environment"
+else
+    git add . >/dev/null 2>&1
+    git commit --quiet --porcelain -m "add LaTeX environment" >/dev/null 2>&1
+fi
 # [ "${GIT_INIT}" != "true" ] && git push --quiet
 
 log "The LaTeX environment integration is complete."


### PR DESCRIPTION
## 問題
ALDC_QUIET=1でquietモードを有効にしても、git操作からの出力が表示されていました：

```
A  .devcontainer/SETUP-devcontainer.md
A  .devcontainer/devcontainer.json
A  .gitattributes
A  .github/auto_assign_myteams.yml
...
```

## 原因
- `git add .` の出力がquietモードでも表示
- `git init .` の出力がquietモードでも表示  
- `git commit` の出力が一部表示

## 解決
### Git操作の条件付き出力抑制
```bash
if [ "$QUIET" = "false" ]; then
    git add .
    git commit --quiet --porcelain -m "add LaTeX environment"
else
    git add . >/dev/null 2>&1
    git commit --quiet --porcelain -m "add LaTeX environment" >/dev/null 2>&1
fi
```

### 初期化時も同様に修正
- `git init .` >/dev/null 2>&1  
- `git add .` >/dev/null 2>&1
- `git commit` >/dev/null 2>&1

## 効果
### Before (ALDC_QUIET=1)
```
download LaTeX environment  # ← log()で既に抑制済み
Integrate LaTeX environment # ← log()で既に抑制済み  
A  .devcontainer/SETUP-devcontainer.md  # ← これが問題
A  .devcontainer/devcontainer.json
A  .gitattributes
...
The LaTeX environment integration is complete. # ← log()で既に抑制済み
```

### After (ALDC_QUIET=1)
```
(完全に無出力)
```

## テスト
- [x] ALDC_QUIET=1で完全に無出力
- [x] 通常モードで正常な出力表示
- [x] git操作の成功確認
- [x] ファイル統合の正常動作