### PR TITLE
Fix silent failures: dry-run commit, undefined RELEASE_BASE, unchecked download

### DIFF
--- a/aldc
+++ b/aldc
@@ -96,7 +96,7 @@ if ! unzip -q "${ZIP_NAME}"; then
     rm -f "${ZIP_NAME}"
     exit 1
 fi
-rm "${ZIP_NAME}"
+rm -f "${ZIP_NAME}"
 cd "${REPOSITORY_NAME}-${BRANCH}" || {
     echo "Error: extracted directory ${REPOSITORY_NAME}-${BRANCH} not found" >&2
     exit 1
@@ -126,7 +126,10 @@ for i in $(find . -type f); do
     fi
 done
 
-cd ..
+cd .. || {
+    echo "Error: failed to return to parent directory" >&2
+    exit 1
+}
 rm -rf "${REPOSITORY_NAME}-${BRANCH}"
 
 if [ "$QUIET" = "false" ]; then

--- a/aldc
+++ b/aldc
@@ -89,6 +89,7 @@ fi
 log "download LaTeX environment"
 if ! curl -fsSLJO "${TARGET}"; then
     echo "Error: failed to download LaTeX environment from ${TARGET}" >&2
+    rm -f "${ZIP_NAME}"
     exit 1
 fi
 if ! unzip -q "${ZIP_NAME}"; then
@@ -134,10 +135,10 @@ rm -rf "${REPOSITORY_NAME}-${BRANCH}"
 
 if [ "$QUIET" = "false" ]; then
     git add .
-    git commit --quiet -m "add LaTeX environment"
+    git diff --cached --quiet || git commit --quiet -m "add LaTeX environment"
 else
     git add . >/dev/null 2>&1
-    git commit --quiet -m "add LaTeX environment" >/dev/null 2>&1
+    git diff --cached --quiet || git commit --quiet -m "add LaTeX environment" >/dev/null 2>&1
 fi
 # [ "${GIT_INIT}" != "true" ] && git push --quiet
 

--- a/aldc
+++ b/aldc
@@ -87,10 +87,20 @@ if [ ! -d .git ]; then
 fi
 
 log "download LaTeX environment"
-curl -sLJO ${TARGET}
-unzip -q ${ZIP_NAME}
-rm ${ZIP_NAME}
-cd ${REPOSITORY_NAME}-${BRANCH}
+if ! curl -fsSLJO "${TARGET}"; then
+    echo "Error: failed to download LaTeX environment from ${TARGET}" >&2
+    exit 1
+fi
+if ! unzip -q "${ZIP_NAME}"; then
+    echo "Error: failed to extract ${ZIP_NAME}" >&2
+    rm -f "${ZIP_NAME}"
+    exit 1
+fi
+rm "${ZIP_NAME}"
+cd "${REPOSITORY_NAME}-${BRANCH}" || {
+    echo "Error: extracted directory ${REPOSITORY_NAME}-${BRANCH} not found" >&2
+    exit 1
+}
 
 # Remove excluded files before integration
 log "Applying file exclusions..."
@@ -117,14 +127,14 @@ for i in $(find . -type f); do
 done
 
 cd ..
-rm -rf ${RELEASE_BASE}
+rm -rf "${REPOSITORY_NAME}-${BRANCH}"
 
 if [ "$QUIET" = "false" ]; then
     git add .
-    git commit --quiet --porcelain -m "add LaTeX environment"
+    git commit --quiet -m "add LaTeX environment"
 else
     git add . >/dev/null 2>&1
-    git commit --quiet --porcelain -m "add LaTeX environment" >/dev/null 2>&1
+    git commit --quiet -m "add LaTeX environment" >/dev/null 2>&1
 fi
 # [ "${GIT_INIT}" != "true" ] && git push --quiet
 


### PR DESCRIPTION
resolve #29

## 修正内容

### 1. `git commit --porcelain` の削除（重大バグ）
`--porcelain` は `git commit` では dry-run を意味するため、「add LaTeX environment」コミットは**実際には一度も作成されていなかった**（変更はステージされたまま）。フラグを削除し、コミットが実際に作成されるようにした。

### 2. 未定義変数 `RELEASE_BASE` の修正
`rm -rf ${RELEASE_BASE}` は空文字に展開され、展開済みの `latex-environment-release/` ディレクトリが削除されずに残っていた。`"${REPOSITORY_NAME}-${BRANCH}"` に修正。

### 3. ダウンロード系のエラーハンドリング追加
`curl` に `-f` を追加し、`curl` / `unzip` / `cd` の失敗時に stderr へ明確なエラーメッセージを出して `exit 1` するようにした。従来はダウンロード失敗後も処理が継続し、分かりにくいエラーになっていた。

## テスト結果

- ✅ `bash -n`: 構文 OK
- ✅ shellcheck: 修正前に存在した SC2164（`cd` 失敗未処理）が解消、新規警告なし（残存警告は既存・本 PR 対象外）
- ✅ 正常系: 一時ディレクトリで実行 → 「add LaTeX environment」コミットが**実際に作成される**ことを確認、残骸ディレクトリ無し、作業ツリークリーン
- ✅ 異常系: 存在しないブランチ URL で実行 → `Error: failed to download LaTeX environment from ...` を表示し exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)